### PR TITLE
Feat/clear old queue

### DIFF
--- a/utils/tx_processor.py
+++ b/utils/tx_processor.py
@@ -64,8 +64,10 @@ class TxProcessor:
                 # 10% chance to perform the old-block check and queue clear
                 if random.random() < 0.1:
                     current_block_number = await self.rpc_helper.get_current_block_number()
+                    self._logger.info(f"🔄 Current block number: {current_block_number}")
                     # check if transaction is more than 100 blocks old
                     receipt_block_number = int(receipt['blockNumber'], 16)  # Convert hex to int
+                    self._logger.info(f"🔄 Receipt block number: {receipt_block_number}")
                     if current_block_number - receipt_block_number > 100:
                         self._logger.warning(f"⚠️ Transaction {tx_hash} is more than 100 blocks old!")
                         # empty the entire queue
@@ -73,6 +75,7 @@ class TxProcessor:
                         self._logger.info("🔄 Cleared entire queue")
                         return
                     else:
+                        self._logger.info(f"🔄 Transaction {tx_hash} is {current_block_number - receipt_block_number} blocks old")
                         self._logger.info(f"🔄 Transaction {tx_hash} is not more than 100 blocks old")
                 # Run all preloader hooks
                 for hook in self.preloader_hooks:

--- a/utils/tx_processor.py
+++ b/utils/tx_processor.py
@@ -72,6 +72,8 @@ class TxProcessor:
                         await self._redis.delete(self.queue_key)
                         self._logger.info("🔄 Cleared entire queue")
                         return
+                    else:
+                        self._logger.info(f"🔄 Transaction {tx_hash} is not more than 100 blocks old")
                 # Run all preloader hooks
                 for hook in self.preloader_hooks:
                     try:


### PR DESCRIPTION
This PR introduces a mechanism to periodically check for and clear old
  transactions from the processing queue in snapshotter-periphery-txprocessor.

  At a 10% chance, a transaction received is checked to see if it is older than
  100 blocks from the latest block. If it is, the Redis queue of transactions is
   cleared and the transaction is not processed. This is to ensure that the
  transaction processor is always working on recent data.

Fixes https://github.com/powerloom/product/issues/274

### Checklist
- [x] My branch is up-to-date with upstream/main branch.
- [x] Everything works and tested for major version of Python/NodeJS/Go and above.
- [x] I ran pre-commit checks against my changes.
- [x] I've written tests against my changes and all the current present tests are passing.
